### PR TITLE
Bump GitHub Actions version to fix CI build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: make -j${nproc} syms
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: symbol-file
           path: ./*.sym


### PR DESCRIPTION
Recent CI builds have been failing due to the issue:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Example: https://github.com/MokhaLeee/FireEmblem7J/actions/runs/13277773091

It looks like this should be resolved by bumping the version of `actions/upload-artifact` to v4, so let's see if that works :)